### PR TITLE
Adds support for chameleon templates and select via cookiecuttter.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,5 @@ Contributors
 - Steve Piercy, 2016-06-08
 
 - Michael Merickel, 2016-11-22
+
+- Michael Kennedy (@mkennedy), 2017-02-28

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Pyramid Scaffold",
-    "repo_name": "scaffold"
+    "repo_name": "scaffold",
+    "template_language": ["jinja2", "chameleon"],
+    "_copy_without_render": [
+        "static/*"
+    ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,53 +1,116 @@
 import os
-import subprocess
 import sys
-
 from textwrap import dedent
 
 WIN = sys.platform.startswith('win')
 
-venv = 'env'
-if WIN:
-    venv_cmd = 'py -3 -m venv'
-    venv_bin = os.path.join(venv, 'Scripts')
-else:
-    venv_cmd = 'python3 -m venv'
-    venv_bin = os.path.join(venv, 'bin')
 
-vars = dict(
-    separator='=' * 79,
-    venv=venv,
-    venv_cmd=venv_cmd,
-    pip_cmd=os.path.join(venv_bin, 'pip'),
-    pytest_cmd=os.path.join(venv_bin, 'pytest'),
-    pserve_cmd=os.path.join(venv_bin, 'pserve'),
-)
-msg = dedent(
-    """
-    %(separator)s
-    Documentation: http://docs.pylonsproject.org/projects/pyramid/en/latest/
-    Tutorials:     http://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/
-    Twitter:       https://twitter.com/trypyramid
-    Mailing List:  https://groups.google.com/forum/#!forum/pylons-discuss
-    Welcome to Pyramid.  Sorry for the convenience.
-    %(separator)s
+def main():
+    clean_unused_template_settings()
+    display_actions_message()
 
-    Change directory into your newly created project.
-        cd {{ cookiecutter.repo_name }}
 
-    Create a Python virtual environment.
-        %(venv_cmd)s %(venv)s
+def clean_unused_template_settings():
+    selected_lang = '{{ cookiecutter.template_language }}'
+    working = os.path.abspath(os.path.join(os.path.curdir))
+    templates = os.path.join(working, '{{cookiecutter.repo_name}}', 'templates')
 
-    Upgrade packaging tools.
-        %(pip_cmd)s install --upgrade pip setuptools
+    layout = None
+    mytemplate = None
+    removal_text = None
+    view = os.path.join(working, '{{cookiecutter.repo_name}}', 'views.py')
 
-    Install the project in editable mode with its testing requirements.
-        %(pip_cmd)s install -e ".[testing]"
+    if selected_lang == 'jinja2':
+        removal_text = ['chameleon', 'mytemplate.pt']
+        layout = os.path.join(templates, 'layout.pt')
+        mytemplate = os.path.join(templates, 'mytemplate.pt')
+    elif selected_lang == 'chameleon':
+        removal_text = ['jinja2']
+        layout = os.path.join(templates, 'layout.jinja2')
+        mytemplate = os.path.join(templates, 'mytemplate.jinja2')
 
-    Run your project's tests.
-        %(pytest_cmd)s
+    delete_files([layout, mytemplate])
 
-    Run your project.
-        %(pserve_cmd)s development.ini
-    """ % vars)
-print(msg)
+    setup = os.path.join(working, 'setup.py')
+    init = os.path.join(working, '{{cookiecutter.repo_name}}', '__init__.py')
+    remove_lines_from_files([setup, init, view], removal_text)
+
+
+def delete_files(files):
+    for file in files:
+        if not os.path.exists(file):
+            print("WARNING: Cookiecutter post generation cannot find file: " + file)
+        else:
+            os.remove(file)
+
+
+def remove_lines_from_files(files, substring_entries):
+    for file in files:
+        if not os.path.exists(file):
+            print("WARNING: Post generation cannot find file: " + file)
+            continue
+
+        with open(file, encoding='utf-8', mode='r') as fin:
+            lines = fin.readlines()
+
+        with open(file, encoding='utf-8', mode='w') as fout:
+            for line in lines:
+                skip_line = False
+                for substring in substring_entries:
+                    if line.find(substring) >= 0:
+                        skip_line = True
+
+                if not skip_line:
+                    fout.write(line)
+
+
+def display_actions_message():
+    venv = 'env'
+    if WIN:
+        venv_cmd = 'py -3 -m venv'
+        venv_bin = os.path.join(venv, 'Scripts')
+    else:
+        venv_cmd = 'python3 -m venv'
+        venv_bin = os.path.join(venv, 'bin')
+
+    vars = dict(
+        separator='=' * 79,
+        venv=venv,
+        venv_cmd=venv_cmd,
+        pip_cmd=os.path.join(venv_bin, 'pip'),
+        pytest_cmd=os.path.join(venv_bin, 'pytest'),
+        pserve_cmd=os.path.join(venv_bin, 'pserve'),
+    )
+    msg = dedent(
+        """
+        %(separator)s
+        Documentation: http://docs.pylonsproject.org/projects/pyramid/en/latest/
+        Tutorials:     http://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/
+        Twitter:       https://twitter.com/trypyramid
+        Mailing List:  https://groups.google.com/forum/#!forum/pylons-discuss
+        Welcome to Pyramid.  Sorry for the convenience.
+        %(separator)s
+    
+        Change directory into your newly created project.
+            cd {{ cookiecutter.repo_name }}
+    
+        Create a Python virtual environment.
+            %(venv_cmd)s %(venv)s
+    
+        Upgrade packaging tools.
+            %(pip_cmd)s install --upgrade pip setuptools
+    
+        Install the project in editable mode with its testing requirements.
+            %(pip_cmd)s install -e ".[testing]"
+    
+        Run your project's tests.
+            %(pytest_cmd)s
+    
+        Run your project.
+            %(pserve_cmd)s development.ini
+        """ % vars)
+    print(msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -50,10 +50,10 @@ def remove_lines_from_files(files, substring_entries):
             print("WARNING: Post generation cannot find file: " + file)
             continue
 
-        with open(file, encoding='utf-8', mode='r') as fin:
+        with open(file, mode='r') as fin:
             lines = fin.readlines()
 
-        with open(file, encoding='utf-8', mode='w') as fout:
+        with open(file, mode='w') as fout:
             for line in lines:
                 skip_line = False
                 for substring in substring_entries:

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -11,6 +11,7 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 requires = [
     'pyramid',
     'pyramid_jinja2',
+    'pyramid_chameleon',
     'pyramid_debugtoolbar',
     'waitress',
 ]

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -6,6 +6,7 @@ def main(global_config, **settings):
     """
     config = Configurator(settings=settings)
     config.include('pyramid_jinja2')
+    config.include('pyramid_chameleon')
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_route('home', '/')
     config.scan()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/layout.pt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/layout.pt
@@ -1,0 +1,62 @@
+<!DOCTYPE html metal:define-macro="layout">
+<html lang="{{ '{{request.locale_name}}' }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="pyramid web application">
+    <meta name="author" content="Pylons Project">
+    <link rel="shortcut icon" href="${request.static_url('{{cookiecutter.repo_name}}:static/pyramid-16x16.png')}">
+
+    <title>Cookiecutter Starter project for the Pyramid Web Framework</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="//oss.maxcdn.com/libs/twitter-bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom styles for this scaffold -->
+    <link href="${request.static_url('{{cookiecutter.repo_name}}:static/theme.css')}" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="//oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+  </head>
+
+  <body>
+
+    <div class="starter-template">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-2">
+            <img class="logo img-responsive" src="${request.static_url('{{cookiecutter.repo_name}}:static/pyramid.png')}" alt="pyramid web framework">
+          </div>
+          <div class="col-md-10">
+            <div metal:define-slot="content">No content</div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="links">
+            <ul>
+              <li><i class="glyphicon glyphicon-cog icon-muted"></i><a href="https://github.com/Pylons/pyramid">Github Project</a></li>
+              <li><i class="glyphicon glyphicon-globe icon-muted"></i><a href="https://webchat.freenode.net/?channels=pyramid">IRC Channel</a></li>
+              <li><i class="glyphicon glyphicon-home icon-muted"></i><a href="http://pylonsproject.org">Pylons Project</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="row">
+          <div class="copyright">
+            Copyright &copy; Pylons Project
+          </div>
+        </div>
+      </div>
+    </div>
+
+
+    <!-- Bootstrap core JavaScript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="//oss.maxcdn.com/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="//oss.maxcdn.com/libs/twitter-bootstrap/3.0.3/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/mytemplate.pt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/mytemplate.pt
@@ -1,0 +1,11 @@
+<div metal:use-macro="load: layout.pt">
+    <div metal:fill-slot="content">
+
+        <div class="content">
+            <h1><span class="font-semi-bold">Pyramid</span> <span class="smaller">Starter project</span></h1>
+            <p class="lead">Welcome to <span class="font-normal">{{cookiecutter.project_name}}</span>, a&nbsp;Pyramid
+                application generated&nbsp;by<br><span class="font-normal">Cookiecutter</span>.</p>
+        </div>
+
+    </div>
+</div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/views.py
@@ -2,5 +2,6 @@ from pyramid.view import view_config
 
 
 @view_config(route_name='home', renderer='templates/mytemplate.jinja2')
+@view_config(route_name='home', renderer='templates/mytemplate.pt')
 def my_view(request):
     return {'project': '{{ cookiecutter.project_name }}'}


### PR DESCRIPTION
This PR adds chameleon support (with layout) to the starter project. The template language is selected via cookiecutter and only relevant files are kept.

```
project_name [Pyramid Scaffold]: Some Project
repo_name [scaffold]: some_project
Select template_language:
1 - jinja2
2 - chameleon
Choose from 1, 2 [1]: 2
```

Fixes issue #12 