### PR TITLE
Use the full project name as the source for package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 *.py[cod]
 /.tox
 /env*/
+.DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ __pycache__
 *.py[cod]
 /.tox
 /env*/
-.DS_Store
-.idea

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "Pyramid Scaffold",
-    "repo_name": "scaffold",
+    "repo_name": "{{cookiecutter.project_name.lower().strip().replace(' ', '_').replace(':', '_').replace('-', '_').replace('!', '_')}}",
     "template_language": ["jinja2", "chameleon", "mako"],
     "_copy_without_render": [
         "static/*"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "Pyramid Scaffold",
-    "repo_name": "{{cookiecutter.project_name.lower().strip().replace(' ', '_').replace(':', '_').replace('-', '_').replace('!', '_')}}",
+    "repo_name": "scaffold",
     "template_language": ["jinja2", "chameleon", "mako"],
     "_copy_without_render": [
         "static/*"


### PR DESCRIPTION
This PR adds a conversion from the full project name to a slugified package name. Here's an example:

<img width="653" alt="screen shot 2017-04-23 at 12 17 02 pm" src="https://cloud.githubusercontent.com/assets/2035561/25316630/9dddfff4-281f-11e7-9da3-9003c816b8bf.png">

Notice the default value of the repo_name.