### PR TITLE
Fix Layout.pt

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -124,3 +124,5 @@ Contributors
 - Marcin Lulek (@ergo), 2018-08-21
 
 - Stephen Martin, 2018-09-18
+
+- Maciej Janowski (@druidmaciek), 2019-11-20

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
@@ -1,5 +1,5 @@
 <!DOCTYPE html metal:define-macro="layout">
-<html lang="{{ '{{request.locale_name}}' }}">
+<html lang="${ '{{request.locale_name}}' }">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
@@ -1,5 +1,5 @@
 <!DOCTYPE html metal:define-macro="layout">
-<html lang="${ '{{request.locale_name}}' }">
+<html lang="{{ '${request.locale_name}' }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
I noticed that in layout.pt HTML tag's lang attribute uses jinja2 syntax instead of chameleon syntax. 