### PR TITLE
Fix DeprecationWarning: Use of .. or absolute path in a resource path…

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_views/default.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_views/default.py
@@ -6,7 +6,7 @@ from pyramid.view import view_config
 from ..models import MyModel
 
 
-@view_config(context=MyModel, renderer='../templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
+@view_config(context=MyModel, renderer='{{ cookiecutter.repo_name }}:templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
 def my_view(request):
     return {'project': '{{ cookiecutter.project_name }}'}
 
@@ -19,7 +19,7 @@ from sqlalchemy.exc import DBAPIError
 from .. import models
 
 
-@view_config(route_name='home', renderer='../templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
+@view_config(route_name='home', renderer='{{ cookiecutter.repo_name }}:templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
 def my_view(request):
     try:
         query = request.dbsession.query(models.MyModel)
@@ -48,7 +48,7 @@ try it again.
 {%- elif cookiecutter.backend == 'none' %}
 
 
-@view_config(route_name='home', renderer='../templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
+@view_config(route_name='home', renderer='{{ cookiecutter.repo_name }}:templates/mytemplate.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
 def my_view(request):
     return {'project': '{{ cookiecutter.project_name }}'}
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_views/notfound.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_views/notfound.py
@@ -1,7 +1,7 @@
 from pyramid.view import notfound_view_config
 
 
-@notfound_view_config(renderer='../templates/404.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
+@notfound_view_config(renderer='{{ cookiecutter.repo_name }}:templates/404.{{ "pt" if "chameleon" == cookiecutter.template_language else cookiecutter.template_language }}')
 def notfound_view(request):
     request.response.status = 404
     return {}


### PR DESCRIPTION
… is not allowed and will raise exceptions in a future release by using the cookiecutter variable repo_name and `:` instead of `../`.

Fixes #75