### PR TITLE
Add `dummy_config` pytest fixture.

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/base_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/base_conftest.py
@@ -51,10 +51,9 @@ def dummy_request():
     """
     A lightweight dummy request.
 
-    This request is ultra-lightweight and should be used only when the
-    request itself is not a large focus in the call-stack.
-
-    It is way easier to mock and control side-effects using this object.
+    This request is ultra-lightweight and should be used only when the request
+    itself is not a large focus in the call-stack.  It is much easier to mock
+    and control side-effects using this object, however:
 
     - It does not have request extensions applied.
     - Threadlocals are not properly pushed.

--- a/{{cookiecutter.repo_name}}/tests/base_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/base_conftest.py
@@ -67,3 +67,14 @@ def dummy_request(app):
     request.host = 'example.com'
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    """
+    A dummy :class:`pyramid.config.Configurator` object.  This allows for
+    mock configuration, including configuration for ``dummy_request``, as well
+    as pushing the appropriate threadlocals.
+
+    """
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/{{cookiecutter.repo_name}}/tests/base_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/base_conftest.py
@@ -41,12 +41,10 @@ def app_request(app):
     drawbacks in tests as it's harder to mock data and is heavier.
 
     """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    yield request
-    env['closer']()
+    with prepare(registry=app.registry) as env:
+        request = env['request']
+        request.host = 'example.com'
+        yield request
 
 @pytest.fixture
 def dummy_request():

--- a/{{cookiecutter.repo_name}}/tests/base_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/base_conftest.py
@@ -49,7 +49,7 @@ def app_request(app):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app):
+def dummy_request():
     """
     A lightweight dummy request.
 
@@ -63,7 +63,6 @@ def dummy_request(app):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
 
     return request

--- a/{{cookiecutter.repo_name}}/tests/base_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/base_conftest.py
@@ -68,7 +68,7 @@ def dummy_request(app):
 
     return request
 
-@pytest.yield_fixture
+@pytest.fixture
 def dummy_config(dummy_request):
     """
     A dummy :class:`pyramid.config.Configurator` object.  This allows for

--- a/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
@@ -105,10 +105,9 @@ def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
-    This request is ultra-lightweight and should be used only when the
-    request itself is not a large focus in the call-stack.
-
-    It is way easier to mock and control side-effects using this object.
+    This request is ultra-lightweight and should be used only when the request
+    itself is not a large focus in the call-stack.  It is much easier to mock
+    and control side-effects using this object, however:
 
     - It does not have request extensions applied.
     - Threadlocals are not properly pushed.

--- a/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
@@ -102,7 +102,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -116,9 +116,19 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    """
+    A dummy :class:`pyramid.config.Configurator` object.  This allows for
+    mock configuration, including configuration for ``dummy_request``, as well
+    as pushing the appropriate threadlocals.
+
+    """
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
@@ -88,18 +88,17 @@ def app_request(app, tm, dbsession):
     drawbacks in tests as it's harder to mock data and is heavier.
 
     """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
+    with prepare(registry=app.registry) as env:
+        request = env['request']
+        request.host = 'example.com'
 
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
+        # without this, request.dbsession will be joined to the same transaction
+        # manager but it will be using a different sqlalchemy.orm.Session using
+        # a separate database transaction
+        request.dbsession = dbsession
+        request.tm = tm
 
-    yield request
-    env['closer']()
+        yield request
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/sqlalchemy_conftest.py
@@ -122,7 +122,7 @@ def dummy_request(tm, dbsession):
 
     return request
 
-@pytest.yield_fixture
+@pytest.fixture
 def dummy_config(dummy_request):
     """
     A dummy :class:`pyramid.config.Configurator` object.  This allows for

--- a/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
@@ -64,10 +64,9 @@ def dummy_request(tm):
     """
     A lightweight dummy request.
 
-    This request is ultra-lightweight and should be used only when the
-    request itself is not a large focus in the call-stack.
-
-    It is way easier to mock and control side-effects using this object.
+    This request is ultra-lightweight and should be used only when the request
+    itself is not a large focus in the call-stack.  It is much easier to mock
+    and control side-effects using this object, however:
 
     - It does not have request extensions applied.
     - Threadlocals are not properly pushed.

--- a/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
@@ -54,13 +54,10 @@ def app_request(app, tm):
     drawbacks in tests as it's harder to mock data and is heavier.
 
     """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-    request.tm = tm
-
-    yield request
-    env['closer']()
+    with prepare(registry=app.registry) as env:
+        request = env['request']
+        request.host = 'example.com'
+        yield request
 
 @pytest.fixture
 def dummy_request(tm):

--- a/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
@@ -63,7 +63,7 @@ def app_request(app, tm):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm):
+def dummy_request(tm):
     """
     A lightweight dummy request.
 
@@ -77,7 +77,6 @@ def dummy_request(app, tm):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.tm = tm
 

--- a/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
@@ -82,3 +82,14 @@ def dummy_request(app, tm):
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    """
+    A dummy :class:`pyramid.config.Configurator` object.  This allows for
+    mock configuration, including configuration for ``dummy_request``, as well
+    as pushing the appropriate threadlocals.
+
+    """
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
+++ b/{{cookiecutter.repo_name}}/tests/zodb_conftest.py
@@ -83,7 +83,7 @@ def dummy_request(app, tm):
 
     return request
 
-@pytest.yield_fixture
+@pytest.fixture
 def dummy_config(dummy_request):
     """
     A dummy :class:`pyramid.config.Configurator` object.  This allows for


### PR DESCRIPTION
Bringing cookiecutter in line with https://github.com/Pylons/pyramid/pull/3629

I'm leaving `app_request` as-is for now.  I'm not sure where we're leaning with it.  @mmerickel, should I bring `app_request` back to the Pyramid PR?