### PR TITLE
Remove deprecation warning

### DIFF
--- a/{{cookiecutter.repo_name}}/pytest.ini
+++ b/{{cookiecutter.repo_name}}/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict
+addopts = --strict-markers
 
 testpaths =
     {{ cookiecutter.repo_name }}


### PR DESCRIPTION
```
 % $VENV/bin/pytest -q                             
# snip
lib/python3.9/site-packages/_pytest/config/__init__.py:1183
  /Users/stevepiercy/projects/hack-on-pyramid/tutorial/lib/python3.9/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(
```