### PR TITLE
Fix #107 pyramid installation note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ Usage
         $ env/bin/pip install --upgrade pip setuptools
         # Install the project in editable mode with its testing requirements.
         $ env/bin/pip install -e ".[testing]"
+        # The previous step installs the latest stable release of Pyramid.
+        # Optionally install a specific version of Pyramid.
+        # For example, the unreleased version of the master branch:
+        env/bin/pip install -e git+https://github.com/pylons/pyramid.git@master#egg=pyramid
 
 #.  If you selected ``sqlalchemy`` as a backend, there will be additional steps in the output and ``README.txt``.
 


### PR DESCRIPTION
This PR fixes #107 by adding a note for installing a specific non-latest stable release of Pyramid. For master branch of the cookiecutter only.