### PR TITLE
ZODB3 has been superseded by ZODB

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -26,7 +26,7 @@ requires = [
     'pyramid_tm',
     'pyramid_zodbconn',
     'transaction',
-    'ZODB3',
+    'ZODB',
     {%- endif %}
 ]
 


### PR DESCRIPTION
Although ZODB3 will still install all the proper dependencies through some packaging redirection black magic, we should save an indirection.