### PR TITLE
Extend SQLAlchemy model to stash the current Request 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,8 @@ unreleased
   inheriting the color of white.
   See https://github.com/Pylons/pyramid-cookiecutter-starter/pull/64
 
+- Extend SQLAlchemy starter to track the current Pyramid Request. Improve some
+  inline docs for SQLAlchemy.
 
 1.10 (2018-10-05)
 -----------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,7 +37,7 @@ unreleased
   inheriting the color of white.
   See https://github.com/Pylons/pyramid-cookiecutter-starter/pull/64
 
-- Extend SQLAlchemy starter to track the current Pyramid Request. Improve some
+- Extend SQLAlchemy to track the current Pyramid request. Improve some
   inline docs for SQLAlchemy.
 
 1.10 (2018-10-05)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,3 +126,5 @@ Contributors
 - Stephen Martin, 2018-09-18
 
 - Julien Cigar, 2019-10-18
+
+- Jonathan Vanasco, 2021-01-27

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
@@ -53,7 +53,7 @@ def get_tm_session(session_factory, transaction_manager, request=None):
     "info" dict.  The "info" dict is the official namespace for developers to
     stash session-specific information.  For more information, please see the
     SQLAlchemy docs:
-    https://docs.sqlalchemy.org/en/stable/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
+    https://docs.sqlalchemy.org/en/stable/orm/session_api.html#sqlalchemy.orm.session.Session.params.info
 
     By placing the active ``request`` in the "info" dict, developers will be able
     to access the active Pyramid request from an instance of a SQLAlchemy

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
@@ -35,14 +35,14 @@ def get_tm_session(session_factory, transaction_manager, request=None):
     - When using scripts you should wrap the session in a manager yourself.
       For example::
 
-          .. code-block:: python
+    .. code-block:: python
 
-          import transaction
+        import transaction
 
-          engine = get_engine(settings)
-          session_factory = get_session_factory(engine)
-          with transaction.manager:
-              dbsession = get_tm_session(session_factory, transaction.manager)
+        engine = get_engine(settings)
+        session_factory = get_session_factory(engine)
+        with transaction.manager:
+            dbsession = get_tm_session(session_factory, transaction.manager)
 
     This function may be invoked with a ``request`` kwarg, such as when invoked
     by the reified ``.dbsession`` Pyramid request attribute which is configured
@@ -61,7 +61,7 @@ def get_tm_session(session_factory, transaction_manager, request=None):
 
     - Classic SQLAlchemy. This uses the ``Session``'s utility classmethod:
 
-        .. code-block:: python
+    .. code-block:: python
 
         from sqlalchemy.orm.session import Session as sa_Session
 
@@ -70,7 +70,7 @@ def get_tm_session(session_factory, transaction_manager, request=None):
 
     - Modern SQLAlchemy. This uses the "Runtime Inspection API":
 
-        .. code-block:: python
+    .. code-block:: python
 
         from sqlalchemy import inspect as sa_inspect
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
@@ -35,6 +35,8 @@ def get_tm_session(session_factory, transaction_manager, request=None):
     - When using scripts you should wrap the session in a manager yourself.
       For example::
 
+          .. code-block:: python
+
           import transaction
 
           engine = get_engine(settings)
@@ -43,27 +45,32 @@ def get_tm_session(session_factory, transaction_manager, request=None):
               dbsession = get_tm_session(session_factory, transaction.manager)
 
     This function may be invoked with a ``request`` kwarg, such as when invoked
-    by the reified ``request.dbsession`` Pyramid Request attribute. The default
-    value, for backwards compatibility, is ``None``.
+    by the reified ``.dbsession`` Pyramid request attribute which is configured
+    via the ``includeme`` function below. The default value, for backwards
+    compatibility, is ``None``.
 
-    - The ``request`` kwarg is used to populate the SQLAlchmey Session's "info"
-      dict.  The "info" dict is the official namespace for developers to stash
-      Session-specific information.  For more information, please see the
-      SQLAlchemy docs:
-      https://docs.sqlalchemy.org/en/13/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
+    The ``request`` kwarg is used to populate the ``sqlalchemy.orm.Session``'s
+    "info" dict.  The "info" dict is the official namespace for developers to
+    stash session-specific information.  For more information, please see the
+    SQLAlchemy docs:
+    https://docs.sqlalchemy.org/en/13/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
 
-    - By placing the active Request in the "info" dict, developers will be able
-      to access the active Pyramid Request from an instance of a SQLAlchemy
-      object in one of two ways:
+    By placing the active ``request`` in the "info" dict, developers will be able
+    to access the active Pyramid request from an instance of a SQLAlchemy
+    object in one of two ways:
 
-    - Classic SQLAlchemy. This uses the Session's utility classmethod:
+    - Classic SQLAlchemy. This uses the ``Session``'s utility classmethod:
+
+        .. code-block:: python
 
         from sqlalchemy.orm.session import Session as sa_Session
 
         dbsession = sa_Session.object_session(dbObject)
         request = dbsession.info["request"]
 
-    - Modern SQLAlchemy. This uses the Runtime API:
+    - Modern SQLAlchemy. This uses the "Runtime Inspection API":
+
+        .. code-block:: python
 
         from sqlalchemy import inspect as sa_inspect
 
@@ -87,8 +94,9 @@ def includeme(config):
     settings['tm.manager_hook'] = 'pyramid_tm.explicit_manager'
 
     # use pyramid_tm to hook the transaction lifecycle to the request
-    # pyramid_tm and transaction will automatically close the database session
-    # if your project migrates away from pyramid_tm, you may need to use a
+    # Note: The packages ``pyramid_tm`` and ``transaction`` work together to
+    # automatically close the active database session after every request.
+    # If your project migrates away from ``pyramid_tm``, you may need to use a
     # Pyramid callback function to close the database session after each request.
     config.include('pyramid_tm')
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
@@ -22,7 +22,7 @@ def get_session_factory(engine):
     return factory
 
 
-def get_tm_session(session_factory, transaction_manager):
+def get_tm_session(session_factory, transaction_manager, request=None):
     """
     Get a ``sqlalchemy.orm.Session`` instance backed by a transaction.
 
@@ -42,8 +42,35 @@ def get_tm_session(session_factory, transaction_manager):
           with transaction.manager:
               dbsession = get_tm_session(session_factory, transaction.manager)
 
+    This function may be invoked with a ``request`` kwarg, such as when invoked
+    by the reified ``request.dbsession`` Pyramid Request attribute. The default
+    value, for backwards compatibility, is ``None``.
+
+    - The ``request`` kwarg is used to populate the SQLAlchmey Session's "info"
+      dict.  The "info" dict is the official namespace for developers to stash
+      Session-specific information.  For more information, please see the
+      SQLAlchemy docs:
+      https://docs.sqlalchemy.org/en/13/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
+
+    - By placing the active Request in the "info" dict, developers will be able
+      to access the active Pyramid Request from an instance of a SQLAlchemy
+      object in one of two ways:
+
+    - Classic SQLAlchemy. This uses the Session's utility classmethod:
+
+        from sqlalchemy.orm.session import Session as sa_Session
+
+        dbsession = sa_Session.object_session(dbObject)
+        request = dbsession.info["request"]
+
+    - Modern SQLAlchemy. This uses the Runtime API:
+
+        from sqlalchemy import inspect as sa_inspect
+
+        dbsession = sa_inspect(dbObject).session
+        request = dbsession.info["request"]
     """
-    dbsession = session_factory()
+    dbsession = session_factory(info={"request": request})
     zope.sqlalchemy.register(
         dbsession, transaction_manager=transaction_manager)
     return dbsession
@@ -60,6 +87,9 @@ def includeme(config):
     settings['tm.manager_hook'] = 'pyramid_tm.explicit_manager'
 
     # use pyramid_tm to hook the transaction lifecycle to the request
+    # pyramid_tm and transaction will automatically close the database session
+    # if your project migrates away from pyramid_tm, you may need to use a
+    # Pyramid callback function to close the database session after each request.
     config.include('pyramid_tm')
 
     # use pyramid_retry to retry a request when transient exceptions occur
@@ -79,7 +109,7 @@ def includeme(config):
         dbsession = request.environ.get('app.dbsession')
         if dbsession is None:
             # request.tm is the transaction manager used by pyramid_tm
-            dbsession = get_tm_session(session_factory, request.tm)
+            dbsession = get_tm_session(session_factory, request.tm, request=request)
         return dbsession
 
     config.add_request_method(dbsession, reify=True)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/__init__.py
@@ -33,16 +33,16 @@ def get_tm_session(session_factory, transaction_manager, request=None):
       depending on whether an exception is raised.
 
     - When using scripts you should wrap the session in a manager yourself.
-      For example::
+      For example:
 
-    .. code-block:: python
+      .. code-block:: python
 
-        import transaction
+          import transaction
 
-        engine = get_engine(settings)
-        session_factory = get_session_factory(engine)
-        with transaction.manager:
-            dbsession = get_tm_session(session_factory, transaction.manager)
+          engine = get_engine(settings)
+          session_factory = get_session_factory(engine)
+          with transaction.manager:
+              dbsession = get_tm_session(session_factory, transaction.manager)
 
     This function may be invoked with a ``request`` kwarg, such as when invoked
     by the reified ``.dbsession`` Pyramid request attribute which is configured
@@ -53,7 +53,7 @@ def get_tm_session(session_factory, transaction_manager, request=None):
     "info" dict.  The "info" dict is the official namespace for developers to
     stash session-specific information.  For more information, please see the
     SQLAlchemy docs:
-    https://docs.sqlalchemy.org/en/13/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
+    https://docs.sqlalchemy.org/en/stable/orm/session_api.html?#sqlalchemy.orm.session.Session.params.info
 
     By placing the active ``request`` in the "info" dict, developers will be able
     to access the active Pyramid request from an instance of a SQLAlchemy
@@ -61,21 +61,21 @@ def get_tm_session(session_factory, transaction_manager, request=None):
 
     - Classic SQLAlchemy. This uses the ``Session``'s utility classmethod:
 
-    .. code-block:: python
+      .. code-block:: python
 
-        from sqlalchemy.orm.session import Session as sa_Session
+          from sqlalchemy.orm.session import Session as sa_Session
 
-        dbsession = sa_Session.object_session(dbObject)
-        request = dbsession.info["request"]
+          dbsession = sa_Session.object_session(dbObject)
+          request = dbsession.info["request"]
 
     - Modern SQLAlchemy. This uses the "Runtime Inspection API":
 
-    .. code-block:: python
+      .. code-block:: python
 
-        from sqlalchemy import inspect as sa_inspect
+          from sqlalchemy import inspect as sa_inspect
 
-        dbsession = sa_inspect(dbObject).session
-        request = dbsession.info["request"]
+          dbsession = sa_inspect(dbObject).session
+          request = dbsession.info["request"]
     """
     dbsession = session_factory(info={"request": request})
     zope.sqlalchemy.register(


### PR DESCRIPTION
This PR extends SQLAlchemy model to stash the current Request into the Session's "info" dict.

To maintain backwards compatibility, the `request` is submitted as an optional kwarg.  IMHO it is best supplied as the first argument - but I didn't want to restructure things too much.

This change allows for SQLAlchemy objects to access the active Pyramid request object.  Without this change, the methods of SQLAlchemy objects must be explicitly passed the current `Request` - which means a `@property` or `@reify` decorated method cannot access this information, unless  the dangerous`get_current_request` is used or developers invest a lot of work in somehow populating this information during various hooks.



