### PR TITLE
renaming `master` branch to `main`

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,10 +1,10 @@
 name: Build and test
 
 on:
-    # Only on pushes to master or one of the release branches we build on push
+    # Only on pushes to main or one of the release branches we build on push
     push:
         branches:
-            - master
+            - main
             - latest
             - "[0-9].[0-9]+-branch"
         tags:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,8 @@ unreleased
   inheriting the color of white.
   See https://github.com/Pylons/pyramid-cookiecutter-starter/pull/64
 
+- Rename "master" branch to "main".
+  See https://github.com/Pylons/pyramid/issues/3712
 
 1.10 (2018-10-05)
 -----------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,16 @@ You can contribute to this project in several ways.
 *   Fork this project, create a new branch, commit your suggested change, and push to your fork on GitHub.
     When ready, submit a pull request for consideration.
     [GitHub Flow](https://guides.github.com/introduction/flow/index.html) describes the workflow process and why it's a good practice.
-    When submitting a pull request, sign [CONTRIBUTORS.txt](https://github.com/Pylons/pyramid-cookiecutter-starter/blob/master/CONTRIBUTORS.txt) if you have not yet done so.
+    When submitting a pull request, sign [CONTRIBUTORS.txt](https://github.com/Pylons/pyramid-cookiecutter-starter/blob/main/CONTRIBUTORS.txt) if you have not yet done so.
 *   Join the [IRC channel #pyramid on irc.freenode.net](https://webchat.freenode.net/?channels=pyramid).
 
 ## Git Branches
 
-*   Submit pull requests to the [`master` branch](https://github.com/Pylons/pyramid-cookiecutter-starter/tree/master).
+*   Submit pull requests to the [`main` branch](https://github.com/Pylons/pyramid-cookiecutter-starter/tree/main).
     This branch is *not* the default and must be selected instead of `latest`.
     See the [README.rst, under Versions](https://github.com/Pylons/pyramid-cookiecutter-starter/#versions).
 *   For development, create a new branch.
-    If changes on your new branch are accepted, they will be merged into the master branch and deployed.
+    If changes on your new branch are accepted, they will be merged into the main branch and deployed.
 
 ## Prerequisites
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,3 +126,5 @@ Contributors
 - Stephen Martin, 2018-09-18
 
 - Julien Cigar, 2019-10-18
+
+- Jonathan Vanasco (@jvanasco), 2022-11-14

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 pyramid-cookiecutter-starter
 ============================
 
-.. image:: https://github.com/Pylons/pyramid-cookiecutter-starter/workflows/Build%20and%20test/badge.svg?branch=master
-    :target: https://github.com/Pylons/pyramid-cookiecutter-starter/actions?query=branch%3Amaster
-    :alt: Master Branch Status
+.. image:: https://github.com/Pylons/pyramid-cookiecutter-starter/workflows/Build%20and%20test/badge.svg?branch=main
+    :target: https://github.com/Pylons/pyramid-cookiecutter-starter/actions?query=branch%3Amain
+    :alt: Main Branch Status
 
 A Cookiecutter (project template) for creating a Pyramid starter project.
 
@@ -26,7 +26,7 @@ Versions
 This cookiecutter has several branches to support new features in Pyramid or avoid incompatibilities.
 
 *   ``latest`` aligns with the latest stable release of Pyramid, and is the default branch on GitHub.
-*   ``master`` aligns with the ``master`` branch of Pyramid, and is where development takes place.
+*   ``main`` aligns with the ``main`` branch of Pyramid, and is where development takes place.
 *   ``x.y-branch`` aligns with the ``x.y-branch`` branch of Pyramid.
 
 
@@ -43,7 +43,7 @@ Usage
 
     .. code-block:: bash
 
-        $ cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+        $ cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 #.  Create a virtual environment, upgrade packaging tools, and install your new project and its dependencies.
     These steps are output to the console and are written to the file in ``<my_project>/README.txt`` by the cookiecutter, and are slightly different for Windows.
@@ -61,8 +61,8 @@ Usage
         $ env/bin/pip install -e ".[testing]"
         # The previous step installs the latest stable release of Pyramid.
         # Optionally install a specific version of Pyramid.
-        # For example, the unreleased version of the master branch:
-        env/bin/pip install -e git+https://github.com/pylons/pyramid.git@master#egg=pyramid
+        # For example, the unreleased version of the main branch:
+        env/bin/pip install -e git+https://github.com/pylons/pyramid.git@main#egg=pyramid
 
 #.  If you selected ``sqlalchemy`` as a backend, there will be additional steps in the output and ``README.txt``.
 


### PR DESCRIPTION
This PR to the "master" branch replaces all occurrences of the "master" branch with "main".  

I believe the two options to handle the rename are:

* copy "master" to "main", set that as default, merge this PR.
or
* merge this PR to "master", then rename to "main" and set that as default.

See also:: https://github.com/Pylons/pyramid/issues/3712