### PR TITLE
Import declarative_base from sqlalchemy.orm

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/meta.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/sqlalchemy_models/meta.py
@@ -1,4 +1,4 @@
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.schema import MetaData
 
 # Recommended naming convention used by Alembic, as various different database


### PR DESCRIPTION
This is to avoid a deprecation warning:

MovedIn20Warning: The ``declarative_base()`` function is now available as
sqlalchemy.orm.declarative_base(). (deprecated since: 1.4)
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)