### PR TITLE
Don't output METAL tag in rendered Chameleon output.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Fix unwanted literal inclusion of a METAL attribute in rendered output within
+  the Chameleon ``layout.pt`` template.
+  
 - Fix deprecation warnings from pytest-cookies.
 
 - Fix missing interpolation in SQLAlchemy model.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -128,3 +128,5 @@ Contributors
 - Julien Cigar, 2019-10-18
 
 - Jonathan Vanasco, 2021-01-27
+
+- Chris McDonough, 2023-03-03

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base_templates/layout.pt
@@ -1,5 +1,5 @@
-<!DOCTYPE html metal:define-macro="layout">
-<html lang="{{ '${request.locale_name}' }}">
+<!DOCTYPE html>
+<html lang="{{ '${request.locale_name}' }}" metal:define-macro="layout">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
If metal:define-macro is present on DOCTYPE, the rendered version of the template retains the literal metal attribute, which causes browsers to be unhappy.  Moving it to the html tag serves the same purpose, but the rendered template does not contain a literal metal tag.

![metalpyramidscaffold](https://github.com/Pylons/pyramid-cookiecutter-starter/assets/125174/0a6039ac-11a9-4591-9c9b-31db291b36c7)
