### PR TITLE
De-specify tag checkout of pytest-cookies requirement

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,6 @@ unreleased
 
 - Fix missing interpolation in SQLAlchemy model.
 
-- Use fork of pytest-cookies to fix tests on windows.
-
 2.0 (2021-02-28)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -128,3 +128,5 @@ Contributors
 - Julien Cigar, 2019-10-18
 
 - Jonathan Vanasco, 2021-01-27
+
+- Chris McDonough, 2023-08-15

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,4 @@
 cookiecutter
 pytest
-# the default pytest-cookies is currently broken on windows
-# https://github.com/hackebrot/pytest-cookies/issues/41#issuecomment-1316992381
-git+https://github.com/jamesmyatt/pytest-cookies@bugfix/62#egg=pytest-cookies
+pytest-cookies
 pytest-venv


### PR DESCRIPTION
The ``bugfix/62`` tag of pytest-cookies is no longer available; this change may cause the tests to fail on Windows, but at least it will work on Linux.