### PR TITLE
Changed to force SQLAlchemy version to be 2 or lower

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -18,7 +18,7 @@ requires = [
     'alembic',
     'pyramid_retry',
     'pyramid_tm',
-    'SQLAlchemy',
+    'SQLAlchemy<2',
     'transaction',
     'zope.sqlalchemy',
     {%- elif cookiecutter.backend == 'zodb' %}


### PR DESCRIPTION
SQLAlchemy recently released version 2.x. The current source code is geared toward SQLAlchemy version 1, so we've made changes in setup.py to install version 2 or lower.